### PR TITLE
Freeze PHP v8.1.19 for EMS v5.6.x

### DIFF
--- a/Dockerfiles/Dockerfile.in
+++ b/Dockerfiles/Dockerfile.in
@@ -1,17 +1,17 @@
 # syntax=docker/dockerfile:1.3
-FROM docker.io/elasticms/base-php:8.1.15-apache-dev as builder
+FROM docker.io/elasticms/base-php:8.1.19-apache-dev as builder
 
 # include(Args.m4)
 # include(Builder.m4)
 
-FROM docker.io/elasticms/base-php:8.1.15-apache as prd
+FROM docker.io/elasticms/base-php:8.1.19-apache as prd
 
 LABEL be.fgov.elasticms.admin.environment="prd"
 
 # include(Args.m4)
 # include(Common.m4)
 
-FROM docker.io/elasticms/base-php:8.1.15-apache-dev as dev
+FROM docker.io/elasticms/base-php:8.1.19-apache-dev as dev
 
 LABEL be.fgov.elasticms.admin.environment="dev"
 

--- a/Dockerfiles/Dockerfile.in
+++ b/Dockerfiles/Dockerfile.in
@@ -1,17 +1,17 @@
 # syntax=docker/dockerfile:1.3
-FROM docker.io/elasticms/base-php:8.1-apache-dev as builder
+FROM docker.io/elasticms/base-php:8.1.15-apache-dev as builder
 
 # include(Args.m4)
 # include(Builder.m4)
 
-FROM docker.io/elasticms/base-php:8.1-apache as prd
+FROM docker.io/elasticms/base-php:8.1.15-apache as prd
 
 LABEL be.fgov.elasticms.admin.environment="prd"
 
 # include(Args.m4)
 # include(Common.m4)
 
-FROM docker.io/elasticms/base-php:8.1-apache-dev as dev
+FROM docker.io/elasticms/base-php:8.1.15-apache-dev as dev
 
 LABEL be.fgov.elasticms.admin.environment="dev"
 


### PR DESCRIPTION
Avoid any side-effects when upgrading the PHP base image (PHP, Curl, Alpine etc.).